### PR TITLE
Set default network name in Traefik config

### DIFF
--- a/templates/traefik-static.yml.j2
+++ b/templates/traefik-static.yml.j2
@@ -19,6 +19,7 @@ providers:
   docker:
     endpoint: "tcp://docker-socket-proxy:2375"
     exposedByDefault: false
+    network: {{ proxy_network_name }}
   file:
     directory: /etc/traefik/dynamic
 


### PR DESCRIPTION
Fixes a bug where otherwise sometimes containers can't be accessed if they have multiple networks